### PR TITLE
[#4040] Remove order filtering by store id

### DIFF
--- a/Model/Resolver/CustomerOrders/Query/OrderFilter.php
+++ b/Model/Resolver/CustomerOrders/Query/OrderFilter.php
@@ -96,16 +96,10 @@ class OrderFilter extends CoreOrderFilter
         );
         $filterGroups[] = $this->filterGroupBuilder->create();
 
-        $this->filterGroupBuilder->setFilters(
-            [$this->filterBuilder->setField('store_id')->setValue($storeId)->setConditionType('eq')->create()]
-        );
-        $filterGroups[] = $this->filterGroupBuilder->create();
-
         // Next lines are added to filter order status by visible on front statuses
         $this->filterGroupBuilder->setFilters(
             [$this->filterBuilder->setField('status')->setValue($this->orderConfig->getVisibleOnFrontStatuses())->setConditionType('in')->create()]
         );
-
         $filterGroups[] = $this->filterGroupBuilder->create();
 
         if (isset($args['filter'])) {


### PR DESCRIPTION
**Related issue**
* Fixes scandipwa/scandipwa#4040

**Problems**
* Orders should not be filtered by store id to be same as on default magento

**In this PR**
* Remove filtering by store id