### PR TITLE
#4018 Removed discount duplicate and added negative attribute to the discount value

### DIFF
--- a/Model/Resolver/Invoice/InvoiceItems.php
+++ b/Model/Resolver/Invoice/InvoiceItems.php
@@ -136,7 +136,7 @@ class InvoiceItems extends SourceInvoiceItems
             'model' => $invoiceItem,
             'product_type' => $orderItem['product_type'],
             'order_item' => $orderItem,
-            'discounts' => $this->formatDiscountDetails($order, $invoiceItem),
+            'discounts' => $this->formatDiscountDetails($order, $invoiceItem),//
             'row_subtotal' => [
                 'value' => $invoiceItem->getRowTotal(),
                 'currency' => $order->getOrderCurrencyCode()
@@ -160,7 +160,7 @@ class InvoiceItems extends SourceInvoiceItems
             $discounts = [];
         } else {
             $discounts[] = [
-                'label' => $associatedOrder->getDiscountDescription() ?? __('Discount'),
+                'label' => $associatedOrder->getDiscountDescription(),
                 'amount' => [
                     'value' => abs($invoiceItem->getDiscountAmount()) ?? 0,
                     'currency' => $associatedOrder->getOrderCurrencyCode()

--- a/Model/Resolver/Invoice/InvoiceItems.php
+++ b/Model/Resolver/Invoice/InvoiceItems.php
@@ -136,7 +136,7 @@ class InvoiceItems extends SourceInvoiceItems
             'model' => $invoiceItem,
             'product_type' => $orderItem['product_type'],
             'order_item' => $orderItem,
-            'discounts' => $this->formatDiscountDetails($order, $invoiceItem),//
+            'discounts' => $this->formatDiscountDetails($order, $invoiceItem),
             'row_subtotal' => [
                 'value' => $invoiceItem->getRowTotal(),
                 'currency' => $order->getOrderCurrencyCode()


### PR DESCRIPTION
Related issue(s):

- Fixes https://github.com/scandipwa/scandipwa/issues/4018

Problem:

- Discount label with no cupom return label as "Discount"

In this PR:

- Return label in case there no cupom applied return null