### PR TITLE
typed getDiscountAmount method as int and getItemId as string

### DIFF
--- a/Model/OrderItem/DataProvider.php
+++ b/Model/OrderItem/DataProvider.php
@@ -252,7 +252,7 @@ class DataProvider extends SourceDataProvider
             $discounts [] = [
                 'label' => $associatedOrder->getDiscountDescription() ?? __('Discount'),
                 'amount' => [
-                    'value' => abs((int)$orderItem->getDiscountAmount()),
+                    'value' => abs((float)$orderItem->getDiscountAmount()),
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/OrderItem/DataProvider.php
+++ b/Model/OrderItem/DataProvider.php
@@ -252,7 +252,7 @@ class DataProvider extends SourceDataProvider
             $discounts [] = [
                 'label' => $associatedOrder->getDiscountDescription() ?? __('Discount'),
                 'amount' => [
-                    'value' => abs((int)$orderItem->getDiscountAmount()) ?? 0,
+                    'value' => abs((int)$orderItem->getDiscountAmount()),
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/OrderItem/DataProvider.php
+++ b/Model/OrderItem/DataProvider.php
@@ -141,7 +141,7 @@ class DataProvider extends SourceDataProvider
             $associatedOrder = $orderList[$orderItem->getOrderId()];
             $itemOptions = $this->optionsProcessor->getItemOptions($orderItem);
             $this->orderItemList[$orderItem->getItemId()] = [
-                'id' => base64_encode($orderItem->getItemId()),
+                'id' => base64_encode((string)$orderItem->getItemId()),
                 'associatedProduct' => $associatedProduct,
                 'model' => $orderItem,
                 'product_name' => $orderItem->getName(),
@@ -248,7 +248,7 @@ class DataProvider extends SourceDataProvider
             $discounts [] = [
                 'label' => $associatedOrder->getDiscountDescription() ?? __('Discount'),
                 'amount' => [
-                    'value' => abs($orderItem->getDiscountAmount()) ?? 0,
+                    'value' => abs((int)$orderItem->getDiscountAmount()) ?? 0,
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/Resolver/CreditMemo/CreditMemoItems.php
+++ b/Model/Resolver/CreditMemo/CreditMemoItems.php
@@ -157,7 +157,7 @@ class CreditMemoItems extends SourceCreditMemoItems
             $discounts[] = [
                 'label' => $associatedOrder->getDiscountDescription() ?? __('Discount'),
                 'amount' => [
-                    'value' => abs($creditmemoItem->getDiscountAmount()) ?? 0,
+                    'value' => abs((int)$creditmemoItem->getDiscountAmount()) ?? 0,
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/Resolver/CreditMemo/CreditMemoItems.php
+++ b/Model/Resolver/CreditMemo/CreditMemoItems.php
@@ -161,7 +161,7 @@ class CreditMemoItems extends SourceCreditMemoItems
             $discounts[] = [
                 'label' => $associatedOrder->getDiscountDescription() ?? __('Discount'),
                 'amount' => [
-                    'value' => abs((int)$creditmemoItem->getDiscountAmount()) ?? 0,
+                    'value' => abs((int)$creditmemoItem->getDiscountAmount()),
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/Resolver/CreditMemo/CreditMemoItems.php
+++ b/Model/Resolver/CreditMemo/CreditMemoItems.php
@@ -161,7 +161,7 @@ class CreditMemoItems extends SourceCreditMemoItems
             $discounts[] = [
                 'label' => $associatedOrder->getDiscountDescription() ?? __('Discount'),
                 'amount' => [
-                    'value' => abs((int)$creditmemoItem->getDiscountAmount()),
+                    'value' => abs((float)$creditmemoItem->getDiscountAmount()),
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/Resolver/Invoice/InvoiceItems.php
+++ b/Model/Resolver/Invoice/InvoiceItems.php
@@ -125,7 +125,7 @@ class InvoiceItems extends SourceInvoiceItems
         $orderItem = $this->orderItemProvider->getOrderItemById((int)$invoiceItem->getOrderItemId());
 
         return [
-            'id' => base64_encode($invoiceItem->getEntityId()),
+            'id' => base64_encode((string)$invoiceItem->getEntityId()),
             'product_name' => $invoiceItem->getName(),
             'product_sku' => $invoiceItem->getSku(),
             'product_sale_price' => [
@@ -162,7 +162,7 @@ class InvoiceItems extends SourceInvoiceItems
             $discounts[] = [
                 'label' => $associatedOrder->getDiscountDescription(),
                 'amount' => [
-                    'value' => abs((int)$invoiceItem->getDiscountAmount()) ?? 0,
+                    'value' => abs((int)$invoiceItem->getDiscountAmount()),
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/Resolver/Invoice/InvoiceItems.php
+++ b/Model/Resolver/Invoice/InvoiceItems.php
@@ -162,7 +162,7 @@ class InvoiceItems extends SourceInvoiceItems
             $discounts[] = [
                 'label' => $associatedOrder->getDiscountDescription(),
                 'amount' => [
-                    'value' => abs((int)$invoiceItem->getDiscountAmount()),
+                    'value' => abs((float)$invoiceItem->getDiscountAmount()),
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/Resolver/Invoice/InvoiceItems.php
+++ b/Model/Resolver/Invoice/InvoiceItems.php
@@ -162,7 +162,7 @@ class InvoiceItems extends SourceInvoiceItems
             $discounts[] = [
                 'label' => $associatedOrder->getDiscountDescription(),
                 'amount' => [
-                    'value' => abs($invoiceItem->getDiscountAmount()) ?? 0,
+                    'value' => abs((int)$invoiceItem->getDiscountAmount()) ?? 0,
                     'currency' => $associatedOrder->getOrderCurrencyCode()
                 ]
             ];

--- a/Model/Resolver/OrderTotal.php
+++ b/Model/Resolver/OrderTotal.php
@@ -134,7 +134,7 @@ class OrderTotal extends SourceOrderTotal
             $orderDiscounts[] = [
                 'label' => $order->getDiscountDescription(),
                 'amount' => [
-                    'value' => abs((int)$order->getDiscountAmount()),
+                    'value' => abs((float)$order->getDiscountAmount()),
                     'currency' => $order->getOrderCurrencyCode()
                 ]
             ];
@@ -213,7 +213,7 @@ class OrderTotal extends SourceOrderTotal
                 [
                     'label' => $order->getDiscountDescription(),
                     'amount' => [
-                        'value' => abs((int)$order->getShippingDiscountAmount()),
+                        'value' => abs((float)$order->getShippingDiscountAmount()),
                         'currency' => $order->getOrderCurrencyCode()
                     ]
                 ];

--- a/Model/Resolver/OrderTotal.php
+++ b/Model/Resolver/OrderTotal.php
@@ -134,7 +134,7 @@ class OrderTotal extends SourceOrderTotal
             $orderDiscounts[] = [
                 'label' => $order->getDiscountDescription(),
                 'amount' => [
-                    'value' => abs($order->getDiscountAmount()),
+                    'value' => abs((int)$order->getDiscountAmount()),
                     'currency' => $order->getOrderCurrencyCode()
                 ]
             ];
@@ -167,7 +167,7 @@ class OrderTotal extends SourceOrderTotal
                 }
             }
         }
-        
+
         return $appliedShippingTaxesForItems;
     }
 
@@ -213,7 +213,7 @@ class OrderTotal extends SourceOrderTotal
                 [
                     'label' => $order->getDiscountDescription(),
                     'amount' => [
-                        'value' => abs($order->getShippingDiscountAmount()),
+                        'value' => abs((int)$order->getShippingDiscountAmount()),
                         'currency' => $order->getOrderCurrencyCode()
                     ]
                 ];


### PR DESCRIPTION
**Related issue(s):**
* Fixes scandipwa/scandipwa#4122

**Problem:**
* Had an error `main.ERROR: abs(): Argument # 1 ($num) must be of type int|float, string given

GraphQL (1:751)
`
For the orders with discount applied

**In this PR:**
* `localmodules/sales-graphql/Model/OrderIten/DataProvider.php `251 line, abs() method couldn't work with the given string, I typed it like int there and `base64_encode()` ,it had error in the linter so I typed it as string (edited) 