### PR TITLE
Add missing import class

### DIFF
--- a/Model/Resolver/CustomerOrders.php
+++ b/Model/Resolver/CustomerOrders.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace ScandiPWA\SalesGraphQl\Model\Resolver;
 
 use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Api\SortOrderBuilder;
 use Magento\Framework\App\ObjectManager;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\GraphQl\Config\Element\Field;


### PR DESCRIPTION
Deployment fails due to missing import class.

Error message:
  Class "ScandiPWA\SalesGraphQl\Model\Resolver\SortOrderBuilder" does not exist                                                                                                             
  Class ScandiPWA\SalesGraphQl\Model\Resolver\CustomerOrders\Interceptor generation error: The requested class did not generate properly, because the 'generated' directory permission is   
  read-only. If --- after running the 'bin/magento setup:di:compile' CLI command when the 'generated' directory permission is set to write --- the requested class did not generate proper  
  ly, then you must add the generated class object to the signature of the related construct method, only.                                                                                  
                                                                                                                